### PR TITLE
Styled admin screen and added a sidebar with links to documentation.

### DIFF
--- a/admin/class-consentcookie-admin.php
+++ b/admin/class-consentcookie-admin.php
@@ -193,6 +193,7 @@ class ConsentCookie_Admin {
             array(
                 'id' 			=> OPT_CC_ENABLED,
                 'value' 		=> 1,
+                'description'   => 'If enabled ConsentCookie is visible on your website.'
             )
             );
 
@@ -209,10 +210,10 @@ class ConsentCookie_Admin {
 
         add_settings_field(
             OPT_CC_WIDGET_CUSTOMSCRIPT,
-            apply_filters( $this->plugin_name . 'label-widget-customscript', esc_html__( 'Script', 'consentcookie' ) ),
+            apply_filters( $this->plugin_name . 'label-widget-customscript', esc_html__( 'Custom script', 'consentcookie' ) ),
             array( $this->adminField, 'field_textarea' ),
             $this->plugin_name,
-            $this->plugin_name . '-general',
+            $this->plugin_name . '-advanced',
             array(
                 'class'         => "large-text jstextarea",
                 'description' 	=> esc_html__ ( 'Custom script' ),
@@ -311,7 +312,7 @@ class ConsentCookie_Admin {
 
         add_settings_section(
             $this->plugin_name . '-general',
-            apply_filters( $this->plugin_name . 'section-title-general', esc_html__( 'ConsentCookie', 'consentcookie' ) ),
+            apply_filters( $this->plugin_name . 'section-title-general', esc_html__( 'General settings', 'consentcookie' ) ),
             array( $this, 'section_general' ),
             $this->plugin_name
             );

--- a/admin/css/consentcookie-admin.css
+++ b/admin/css/consentcookie-admin.css
@@ -15,3 +15,11 @@ textarea.jstextarea {
 #ccBtnReset {
 	margin-left: 10px;
 }
+
+.settings_field {
+	margin-bottom: 30px;
+}
+
+.settings_field_title {
+	margin-bottom: unset;
+}

--- a/admin/partials/consentcookie-admin-page-settings.php
+++ b/admin/partials/consentcookie-admin-page-settings.php
@@ -11,18 +11,129 @@
  * @subpackage ConsentCookie/admin/partials
  */
 
+function do_settings_sections_cc( $page ) {
+    global $wp_settings_sections, $wp_settings_fields;
+
+    if ( ! isset( $wp_settings_sections[$page] ) )
+        return;
+
+    foreach ( (array) $wp_settings_sections[$page] as $section ) {
+        if ( $section['title'] )
+            echo "<h1>{$section['title']}</h1>\n";
+
+        if ( $section['callback'] )
+            call_user_func( $section['callback'], $section );
+
+        if ( ! isset( $wp_settings_fields ) || !isset( $wp_settings_fields[$page] ) || !isset( $wp_settings_fields[$page][$section['id']] ) )
+            continue;
+        echo '<p>';
+        do_settings_fields_cc( $page, $section['id'] );
+        echo '</p>';
+    }
+}
+
+
+function do_settings_fields_cc($page, $section) {
+    global $wp_settings_fields;
+
+    if ( ! isset( $wp_settings_fields[$page][$section] ) )
+        return;
+
+    foreach ( (array) $wp_settings_fields[$page][$section] as $field ) {
+        $class = '';
+
+        if ( ! empty( $field['args']['class'] ) ) {
+            $class = ' class="' . esc_attr( $field['args']['class'] ) . '"';
+        }
+
+        echo "<p class='settings_field'>";
+
+        if ( ! empty( $field['args']['label_for'] ) ) {
+            echo '<h4 class="settings_field_title" scope="row"><label for="' . esc_attr( $field['args']['label_for'] ) . '">' . $field['title'] . '</label></h4>';
+        } else {
+            echo '<h4 class="settings_field_title" scope="row">' . $field['title'] . '</h4>';
+        }
+
+
+        call_user_func($field['callback'], $field['args']);
+        echo "</p>";
+    }
+}
+
+
 ?>
-<form id="consentcookie-form" method="post" action="options.php"><?php
+<div class="wrap">
+    <h2><?php echo 'ConsentCookie' ?> &raquo; <?php _e('Settings', $this->plugin_name); ?></h2>
 
-settings_fields( $this->plugin_name . '-options' );
+    <?php
+    if (isset($this->message)) {
+        ?>
+        <div class="updated fade"><p><?php echo $this->message; ?></p></div>
+        <?php
+    }
+    if (isset($this->errorMessage)) {
+        ?>
+        <div class="error fade"><p><?php echo $this->errorMessage; ?></p></div>
+        <?php
+    }
+    ?>
 
-submit_button( esc_html__( 'Save' ), "primary", $this->plugin_name . "-submit-top", true /*, array( 'disabled' => 'disabled' ) */ );
+    <div id="poststuff">
+        <div id="post-body" class="metabox-holder columns-2">
+            <!-- Content -->
+            <div id="post-body-content">
+                <div id="normal-sortables" class="meta-box-sortables ui-sortable">
+                    <div class="postbox">
+                        <div class="inside">
+                            <form id="consentcookie-form" method="post" action="options.php">
+                                <?php
 
-do_settings_sections( $this->plugin_name );
+                                settings_fields($this->plugin_name . '-options');
 
-?>
-<p class="submit">
-<?php submit_button( esc_html__( 'Save' ), "primary", $this->plugin_name . "-submit-bottom", false /*, array( 'disabled' => 'disabled' )*/ ); ?>
-<input id="ccBtnReset" value="<?php echo esc_html__( 'Reset', 'consentcookie' ) ?>" title="<?php echo esc_html__( 'Reset to initial settings', 'consentcookie' ) ?>" class="button" type="button" onclick = "consentCookieAdmin.reset()">
-</p>
-</form>
+                                do_settings_sections_cc($this->plugin_name);
+
+                                ?>
+
+                                <p>
+                                    <?php submit_button(esc_html__('Save'), "primary", $this->plugin_name . "-submit-bottom", false /*, array( 'disabled' => 'disabled' )*/); ?>
+                                    <input id="ccBtnReset" value="<?php echo esc_html__('Reset', 'consentcookie') ?>"
+                                           title="<?php echo esc_html__('Reset to initial settings', 'consentcookie') ?>"
+                                           class="button"
+                                           type="button" onclick="consentCookieAdmin.reset()">
+                                </p>
+                            </form>
+                        </div>
+                    </div>
+
+                </div>
+                <!-- /normal-sortables -->
+            </div>
+            <!-- /post-body-content -->
+
+            <!-- Sidebar -->
+            <div id="postbox-container-1" class="postbox-container">
+                <div class="postbox">
+                    <h3 class="hndle"><?php _e('Your site GDPR compliant?', $this->plugin_name); ?></h3>
+                    <div class="inside">
+                       Implement ConsentCookie in the correct way to make your website GDPR compliant.
+                        <ul>
+                            <li><a href="https://www.consentcookie.nl/doc/consentcookie-v1-x/" target="_blank">Documentation</a> </li>
+                            <li><a href="https://www.consentcookie.nl/knowledgebase/" target="_blank">Knowledgebase</a> </li>
+                            <li><a href="https://www.consentcookie.nl/faq/algemeen/" target="_blank">FAQ</a> </li>
+
+                        </ul>
+                        Get <a href="https://www.consentcookie.nl/consentcookie-premium/" target="_blank">Premium</a> and stay up-to-date with the latest ConsentCookie version hosted by <a href="https://www.humanswitch.io" target="_blank">HumanSwitch</a>.
+                    </div>
+                </div>
+                <div class="postbox">
+                    <h3 class="hndle"><?php _e('HumanSwitch', $this->plugin_name); ?></h3>
+                    <div class="inside">
+                        We are experts in adding human dimension to digital transformation. <a href="https://www.humanswitch.io" target="_blank">Check out</a> our other services.
+                    </div>
+                </div>
+            </div>
+            <!-- /postbox-container -->
+        </div>
+    </div>
+</div>
+

--- a/includes/class-consentcookie.php
+++ b/includes/class-consentcookie.php
@@ -56,7 +56,7 @@ class ConsentCookie {
 	 * @var      string    $version    The current version of the plugin.
 	 */
 	protected $version;
-	
+
 	/**
 	 * Sanitizer for cleaning user input
 	 *
@@ -65,7 +65,7 @@ class ConsentCookie {
 	 * @var      ConsentCookie_Sanitize    $sanitizer    Sanitizes data
 	 */
 	private $sanitizer;
-	
+
 	private $options;
 
 	/**
@@ -81,12 +81,12 @@ class ConsentCookie {
 		$this->version = PLUGIN_VERSION;
 		$this->plugin_name = 'consentcookie';
 		$this->options = get_option( $this->plugin_name . '-options' );
-		
+
 		$this->load_dependencies();
 		$this->set_locale();
 		$this->define_admin_hooks();
 		$this->define_public_hooks();
-		
+
 	}
 
 	/**
@@ -129,15 +129,15 @@ class ConsentCookie {
 		 * side of the site.
 		 */
 		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'public/class-consentcookie-public.php';
-		
+
 		/**
 		 * The class responsible for sanitizing user input
 		 */
 		require_once plugin_dir_path( dirname( __FILE__ ) ) . 'includes/class-consentcookie-sanitize.php';
-		
+
 		$this->loader = new ConsentCookie_Loader();
 		$this->sanitizer = new ConsentCookie_Sanitize();
-		
+
 	}
 
 	/**
@@ -165,9 +165,9 @@ class ConsentCookie {
 	 * @access   private
 	 */
 	private function define_admin_hooks() {
-	    if ( is_admin() ) {	    
+	    if ( is_admin() ) {
 	        $plugin_admin = new ConsentCookie_Admin( $this->get_consentcookie(), $this->get_version() );
-	        
+
 	        $this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_styles' );
 	        $this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_scripts' );
 	        $this->loader->add_action( 'admin_menu', $plugin_admin, 'add_menu' );
@@ -176,12 +176,12 @@ class ConsentCookie {
 	        $this->loader->add_action( 'admin_init', $plugin_admin, 'register_fields' );
 	        $this->loader->add_action( 'admin_notices', $plugin_admin, 'register_update_notice' );
 	    }
-		
+
 	}
-	
+
 	private function is_enabled() {
 	    return $this->options[OPT_CC_ENABLED];
-	}	
+	}
 
 	/**
 	 * Register all of the hooks related to the public-facing functionality


### PR DESCRIPTION
Added Sidebar:
- Block with support links
- Block with HumanSwitch explanation

- Added different header title
- First settings section is renamed from 'ConsentCookie' to 'General settings'
- Added descriptions to advanced and general section
- Moved Custom script to advanced area
- Removed 'save' on top because of styling
- Added field css